### PR TITLE
Add Crossplane AWS IAM automation for OCP installer credentials

### DIFF
--- a/cluster-templates/aws-ha/base/crossplane/README.md
+++ b/cluster-templates/aws-ha/base/crossplane/README.md
@@ -1,0 +1,100 @@
+# Crossplane AWS IAM Resources
+
+This folder contains Crossplane manifests to provision AWS IAM credentials for an OpenShift cluster installer user.
+
+## Resource Inventory
+
+| File | Kind | Name | Purpose |
+|------|------|------|---------|
+| `provider.yaml` | `Provider` + `ProviderConfig` | `provider-aws-iam` / `default` | Installs the Upbound AWS IAM provider (`v1.20.0`) and binds it to the `aws-credentials` secret |
+| `iam-user.yaml` | `User` | `ocp-installer` | Creates an AWS IAM user for the OpenShift installer |
+| `iam-policy.yaml` | `Policy` | `OpenShift4InstallerPolicy` | IAM policy with EC2, ELB, autoscaling, IAM, S3, Route53, and service-quotas permissions required for OCP 4.20 installation |
+| `iam-attachment.yaml` | `UserPolicyAttachment` | `ocp-installer-policy-attachment` | Attaches `OpenShift4InstallerPolicy` to the `ocp-installer` user |
+| `iam-access-key.yaml` | `AccessKey` | `ocp-installer-access-key` | Generates an AWS access key and writes the credentials to the `ocp-installer-credentials` secret in the `default` namespace |
+
+## Prerequisites
+
+### 1. Install Crossplane
+
+Crossplane must be installed on your cluster. The recommended way is via Helm:
+
+```bash
+helm repo add crossplane-stable https://charts.crossplane.io/stable
+helm repo update
+helm install crossplane crossplane-stable/crossplane \
+  --namespace crossplane-system \
+  --create-namespace
+```
+
+See the [official Crossplane installation docs](https://docs.crossplane.io/latest/get-started/install/) for more options.
+
+### 2. Create the AWS credentials secret (one-time setup)
+
+This secret is used by the `ProviderConfig` in `provider.yaml` to authenticate with AWS:
+
+```bash
+kubectl create secret generic aws-credentials \
+  -n crossplane-system \
+  --from-literal=credentials="[default]
+aws_access_key_id = YOUR_KEY
+aws_secret_access_key = YOUR_SECRET"
+```
+
+## Usage
+
+### 1. Apply the provider and wait for it to become healthy
+
+`provider.yaml` contains both the `Provider` package install and the `ProviderConfig` that binds it to the `aws-credentials` secret. The provider must be healthy before the IAM resources can be applied:
+
+```bash
+kubectl apply -f crossplane/provider.yaml
+kubectl wait provider provider-aws-iam --for=condition=Healthy --timeout=120s
+```
+
+### 2. Apply the IAM resources
+
+```bash
+kubectl apply -f crossplane/iam-user.yaml \
+              -f crossplane/iam-policy.yaml \
+              -f crossplane/iam-attachment.yaml \
+              -f crossplane/iam-access-key.yaml
+```
+
+### 3. Verify the resources were reconciled
+
+Check that all resources are synced and ready:
+
+```bash
+kubectl get user,policy,userpolicyattachment,accesskey \
+  -l app.kubernetes.io/part-of=ocp-installer
+```
+
+All resources should show `READY: True` and `SYNCED: True`.
+
+## Retrieving the Generated Credentials
+
+Once the `AccessKey` resource is ready, Crossplane writes the generated AWS credentials to a secret in the `default` namespace:
+
+```bash
+kubectl get secret ocp-installer-credentials -n default \
+  -o jsonpath='{.data}' | jq 'map_values(@base64d)'
+```
+
+The secret contains the `username`, `id` (access key ID), and `secret` (secret access key) fields that can be used for OpenShift cluster installation.
+
+## Cleanup
+
+To delete all IAM resources, apply in reverse order to respect dependencies (access key and attachment before policy and user):
+
+```bash
+kubectl delete -f crossplane/iam-access-key.yaml \
+               -f crossplane/iam-attachment.yaml \
+               -f crossplane/iam-policy.yaml \
+               -f crossplane/iam-user.yaml
+```
+
+Crossplane will delete the corresponding AWS resources before removing the Kubernetes objects. To also remove the provider:
+
+```bash
+kubectl delete -f crossplane/provider.yaml
+```

--- a/cluster-templates/aws-ha/base/crossplane/iam-access-key.yaml
+++ b/cluster-templates/aws-ha/base/crossplane/iam-access-key.yaml
@@ -1,0 +1,13 @@
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: AccessKey
+metadata:
+  name: ocp-installer-access-key
+  labels:
+    app.kubernetes.io/part-of: ocp-installer
+spec:
+  forProvider:
+    userRef:
+      name: ocp-installer
+  writeConnectionSecretToRef:
+    name: ocp-installer-credentials
+    namespace: default

--- a/cluster-templates/aws-ha/base/crossplane/iam-attachment.yaml
+++ b/cluster-templates/aws-ha/base/crossplane/iam-attachment.yaml
@@ -1,0 +1,12 @@
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: UserPolicyAttachment
+metadata:
+  name: ocp-installer-policy-attachment
+  labels:
+    app.kubernetes.io/part-of: ocp-installer
+spec:
+  forProvider:
+    userRef:
+      name: ocp-installer
+    policyArnRef:
+      name: openshift4-installer-policy

--- a/cluster-templates/aws-ha/base/crossplane/iam-policy.yaml
+++ b/cluster-templates/aws-ha/base/crossplane/iam-policy.yaml
@@ -1,0 +1,138 @@
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: Policy
+metadata:
+  name: openshift4-installer-policy
+  labels:
+    app.kubernetes.io/part-of: ocp-installer
+spec:
+  forProvider:
+    description: "Permissions required for OpenShift 4.20 installation on AWS"
+    name: OpenShift4InstallerPolicy
+    tags:
+      Purpose: OpenShift-Installer
+      CreatedBy: Crossplane
+      Product: OpenShift
+    policy: |
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Sid": "EC2NetworkAndCompute",
+            "Effect": "Allow",
+            "Action": [
+              "ec2:*",
+              "elasticloadbalancing:*",
+              "autoscaling:*",
+              "tag:GetResources",
+              "tag:UntagResources"
+            ],
+            "Resource": "*"
+          },
+          {
+            "Sid": "IAMRoleManagement",
+            "Effect": "Allow",
+            "Action": [
+              "iam:AddRoleToInstanceProfile",
+              "iam:CreateInstanceProfile",
+              "iam:CreateRole",
+              "iam:DeleteInstanceProfile",
+              "iam:DeleteRole",
+              "iam:DeleteRolePolicy",
+              "iam:GetInstanceProfile",
+              "iam:GetRole",
+              "iam:GetRolePolicy",
+              "iam:GetUser",
+              "iam:ListInstanceProfilesForRole",
+              "iam:ListRoles",
+              "iam:ListUsers",
+              "iam:PassRole",
+              "iam:PutRolePolicy",
+              "iam:RemoveRoleFromInstanceProfile",
+              "iam:SimulatePrincipalPolicy",
+              "iam:TagInstanceProfile",
+              "iam:TagRole",
+              "iam:UntagRole",
+              "iam:ListAttachedRolePolicies",
+              "iam:ListInstanceProfiles",
+              "iam:ListRolePolicies",
+              "iam:ListUserPolicies",
+              "iam:DeleteAccessKey",
+              "iam:DeleteUser",
+              "iam:DeleteUserPolicy",
+              "iam:GetUserPolicy",
+              "iam:ListAccessKeys",
+              "iam:PutUserPolicy",
+              "iam:TagUser"
+            ],
+            "Resource": "*"
+          },
+          {
+            "Sid": "S3ClusterState",
+            "Effect": "Allow",
+            "Action": [
+              "s3:CreateBucket",
+              "s3:DeleteBucket",
+              "s3:GetAccelerateConfiguration",
+              "s3:GetBucketAcl",
+              "s3:GetBucketCors",
+              "s3:GetBucketLocation",
+              "s3:GetBucketLogging",
+              "s3:GetBucketObjectLockConfiguration",
+              "s3:GetBucketPolicy",
+              "s3:GetBucketRequestPayment",
+              "s3:GetBucketTagging",
+              "s3:GetBucketVersioning",
+              "s3:GetBucketWebsite",
+              "s3:GetEncryptionConfiguration",
+              "s3:GetLifecycleConfiguration",
+              "s3:GetReplicationConfiguration",
+              "s3:ListBucket",
+              "s3:PutBucketAcl",
+              "s3:PutBucketPolicy",
+              "s3:PutBucketTagging",
+              "s3:PutEncryptionConfiguration",
+              "s3:AbortMultipartUpload",
+              "s3:GetBucketPublicAccessBlock",
+              "s3:ListBucketMultipartUploads",
+              "s3:PutBucketPublicAccessBlock",
+              "s3:PutLifecycleConfiguration",
+              "s3:DeleteObject",
+              "s3:GetObject",
+              "s3:GetObjectAcl",
+              "s3:GetObjectTagging",
+              "s3:GetObjectVersion",
+              "s3:PutObject",
+              "s3:PutObjectAcl",
+              "s3:PutObjectTagging",
+              "s3:ListBucketVersions"
+            ],
+            "Resource": "*"
+          },
+          {
+            "Sid": "Route53DNS",
+            "Effect": "Allow",
+            "Action": [
+              "route53:ChangeResourceRecordSets",
+              "route53:ChangeTagsForResource",
+              "route53:CreateHostedZone",
+              "route53:DeleteHostedZone",
+              "route53:GetChange",
+              "route53:GetHostedZone",
+              "route53:ListHostedZones",
+              "route53:ListHostedZonesByName",
+              "route53:ListResourceRecordSets",
+              "route53:ListTagsForResource",
+              "route53:UpdateHostedZoneComment"
+            ],
+            "Resource": "*"
+          },
+          {
+            "Sid": "ServiceQuotas",
+            "Effect": "Allow",
+            "Action": [
+              "servicequotas:ListAWSDefaultServiceQuotas"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }

--- a/cluster-templates/aws-ha/base/crossplane/iam-user.yaml
+++ b/cluster-templates/aws-ha/base/crossplane/iam-user.yaml
@@ -1,0 +1,12 @@
+apiVersion: iam.aws.upbound.io/v1beta1
+kind: User
+metadata:
+  name: ocp-installer
+  labels:
+    app.kubernetes.io/part-of: ocp-installer
+spec:
+  forProvider:
+    tags:
+      Purpose: OpenShift-Installer
+      CreatedBy: Crossplane
+      Product: OpenShift

--- a/cluster-templates/aws-ha/base/crossplane/provider.yaml
+++ b/cluster-templates/aws-ha/base/crossplane/provider.yaml
@@ -1,0 +1,18 @@
+apiVersion: pkg.crossplane.io/v1
+kind: Provider
+metadata:
+  name: provider-aws-iam
+spec:
+  package: xpkg.upbound.io/upbound/provider-aws-iam:v1.20.0
+---
+apiVersion: aws.upbound.io/v1beta1
+kind: ProviderConfig
+metadata:
+  name: default
+spec:
+  credentials:
+    source: Secret
+    secretRef:
+      namespace: crossplane-system
+      name: aws-credentials
+      key: credentials


### PR DESCRIPTION
- Adds Crossplane manifests to provision AWS IAM credentials for the OpenShift installer user per cluster (`provider`, `iam-user`, `iam-policy`, `iam-attachment`, `iam-access-key`)
- Moves the Crossplane resources into `cluster-templates/aws-ha/base/crossplane/` to align with the existing Kustomize base/overlay pattern
- Adds a `README.md` covering prerequisites, resource inventory, usage, verification, credential retrieval, and cleanup

closes #2 